### PR TITLE
Make return() more forgiving

### DIFF
--- a/Syntaxes/VCL.tmLanguage
+++ b/Syntaxes/VCL.tmLanguage
@@ -217,12 +217,6 @@
           <key>name</key>
           <string>constant.language.return.vcl</string>
         </dict>
-        <dict>
-          <key>match</key>
-          <string>.*</string>
-          <key>name</key>
-          <string>meta.error.vcl</string>
-        </dict>
       </array>
     </dict>
     <dict>


### PR DESCRIPTION
Looks like the nested `synth()` is breaking the regex for `return()`. I removed the catch all error, so this should relax things a bit.

![sublime](https://user-images.githubusercontent.com/1030507/34309593-d328c336-e720-11e7-96a4-35d140816891.png)