### PR TITLE
Add support for ssl properties

### DIFF
--- a/Syntaxes/VCL.tmLanguage
+++ b/Syntaxes/VCL.tmLanguage
@@ -316,7 +316,7 @@
           <key>name</key>
           <string>variable.subkey.vcl</string>
           <key>match</key>
-          <string>\.(max_connections|first_byte_timeout|between_bytes_timeout|probe|host_header|retries|backend|weight|host|list|port|connect_timeout|ttl|suffix|url|request|window|threshold|initial|expected_response|interval|timeout)\b</string>
+          <string>\.(max_connections|first_byte_timeout|between_bytes_timeout|probe|host_header|retries|backend|weight|host|list|port|connect_timeout|ttl|suffix|url|request|window|threshold|initial|expected_response|interval|timeout|ssl|ssl_nosni|ssl_noverify)\b</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
Varnish Cache Plus supports SSL/TLS encryption. A backend can have ssl* properties:

    backend default {
      .host = "host.name";
      .port = "https";       # This defaults to https when SSL
      .ssl = 1;              # Turns on SSL support
      .ssl_nosni = 0;        # Disable SNI extension
      .ssl_noverify = 1;     # Don't verify peer
    }

See https://github.com/varnish/Varnish-Book/blob/master/varnish_book.rst for reference.